### PR TITLE
- Added the ability for On Demand recognitions to run without the Mag…

### DIFF
--- a/overlay/src/main/aidl/com/kieronquinn/app/ambientmusicmod/IShellProxy.aidl
+++ b/overlay/src/main/aidl/com/kieronquinn/app/ambientmusicmod/IShellProxy.aidl
@@ -18,7 +18,7 @@ interface IShellProxy {
     int AudioRecord_getBufferSizeInFrames() = 9;
     int AudioRecord_getSampleRate() = 10;
 
-    //MusicRecognitionManager proxy
+    //MusicRecognitionManager proxy (only used externally)
     void MusicRecognitionManager_beginStreamingSearch(in RecognitionRequest request, in IRecognitionCallback callback) = 11;
 
     //Sensor Privacy checks for AMM UI & to know when to not recognise
@@ -40,6 +40,14 @@ interface IShellProxy {
 
     //Force stops Now Playing to force a reload of data
     oneway void forceStopNowPlaying() = 19;
+
+    //MusicRecognitionManager proxy with added thread injection (not exposed externally)
+    void MusicRecognitionManager_beginStreamingSearchWithThread(
+        in RecognitionRequest request,
+        in IRecognitionCallback callback,
+        in IBinder thread,
+        in IBinder token
+    ) = 20;
 
     void destroy() = 16777114;
 

--- a/overlay/src/main/java/com/kieronquinn/app/pixelambientmusic/Injector.kt
+++ b/overlay/src/main/java/com/kieronquinn/app/pixelambientmusic/Injector.kt
@@ -6,6 +6,7 @@ import com.kieronquinn.app.pixelambientmusic.components.albumart.AlbumArtRetriev
 import com.kieronquinn.app.pixelambientmusic.config.DeviceConfigOverrides
 import com.kieronquinn.app.pixelambientmusic.providers.LevelDbProvider
 import com.kieronquinn.app.pixelambientmusic.service.ServiceController
+import com.kieronquinn.app.pixelambientmusic.utils.extensions.clearDumpFiles
 import com.kieronquinn.app.pixelambientmusic.xposed.XposedHooks
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.lsposed.hiddenapibypass.HiddenApiBypass
@@ -18,7 +19,7 @@ import java.security.Security
 class Injector: AiaiApplication() {
 
     companion object {
-        const val DEBUG = true //TODO disable
+        const val DEBUG = false
     }
 
     override fun attachBaseContext(base: Context) {
@@ -29,6 +30,10 @@ class Injector: AiaiApplication() {
         ServiceController.createInstance(base)
         AlbumArtRetriever.createInstance(base)
         XposedHooks.setupHooks(base)
+        if(!DEBUG){
+            //Clean up any previously left over dump files
+            base.clearDumpFiles()
+        }
         super.attachBaseContext(base)
     }
 

--- a/overlay/src/main/java/com/kieronquinn/app/pixelambientmusic/utils/extensions/Extensions+Context.kt
+++ b/overlay/src/main/java/com/kieronquinn/app/pixelambientmusic/utils/extensions/Extensions+Context.kt
@@ -9,6 +9,12 @@ fun Context.dumpToFile(name: String, bytes: ByteArray) {
     }
 }
 
+fun Context.clearDumpFiles() {
+    filesDir.listFiles()?.filter { it.extension == "bin" }?.forEach {
+        it.delete()
+    }
+}
+
 fun Context.getVersion(): Long {
     return packageManager.getPackageInfo(packageName, 0).longVersionCode
 }

--- a/variables.gradle.kts
+++ b/variables.gradle.kts
@@ -1,5 +1,5 @@
-val versionName = "1.0.2"
-val versionCode = 102
+val versionName = "1.0.3"
+val versionCode = 103
 val minSdk = 28
 val targetSdk = 31
 val supportedAbis = arrayOf("arm64-v8a", "armeabi-v7a")


### PR DESCRIPTION
…isk overlay module, **so long as the device is rooted**. You must start Shizuku as root or use Sui to make use of this method, and the overlay is still preferred if it works on your device. Please read the [Wiki page](https://github.com/KieronQuinn/AmbientMusicMod/wiki/Enabling-On-Demand) for more information.

- Minor bug fixes